### PR TITLE
feat: add WSL support with Linux GUI Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ WTAgent connects GPT Web to your local project: GPT reasons in the browser while
 
 ## Quick start
 
-Requires Node.js 20.17+ and Chrome/Chromium. WTAgent supports macOS, Linux, and native Windows. WSL is not currently supported.
+Requires Node.js 20.17+ and Chrome/Chromium. WTAgent supports macOS, Linux, native Windows, and WSL with WSLg or another Linux graphical display.
+
+On WSL, install the Linux Chrome/Chromium package inside the distribution and launch WTAgent from WSL. WTAgent keeps file and command execution in the WSL environment and connects to that Linux browser over local CDP. Windows-host Chrome is not supported from WSL yet.
 
 ```bash
 npm install -g wtagent
@@ -49,7 +51,9 @@ WTAgent 将 GPT 网页聊天连接到本地项目：GPT 在浏览器中思考，
 
 ### 快速开始
 
-需要 Node.js 20.17+ 和 Chrome/Chromium。支持 macOS、Linux 和原生 Windows，暂不支持 WSL。
+需要 Node.js 20.17+ 和 Chrome/Chromium。支持 macOS、Linux、原生 Windows，以及带 WSLg 或其他 Linux 图形显示环境的 WSL。
+
+在 WSL 中使用时，需要在 WSL 发行版内部安装 Linux 版 Chrome/Chromium，并从 WSL 启动 WTAgent。文件读写和命令执行仍然发生在 WSL 环境中，WTAgent 通过本地 CDP 连接这个 Linux 浏览器。当前还不支持从 WSL 直接控制 Windows 主机上的 Chrome。
 
 ```bash
 npm install -g wtagent

--- a/src/platform/windows-diagnostics.js
+++ b/src/platform/windows-diagnostics.js
@@ -55,6 +55,34 @@ export function detectWsl({
   );
 }
 
+export function getWslSupport({
+  platform = process.platform,
+  env = process.env,
+  osRelease = os.release(),
+} = {}) {
+  if (!detectWsl({ platform, env, osRelease })) {
+    return { supported: true, preview: false, reason: null };
+  }
+
+  const display = env.WAYLAND_DISPLAY || env.DISPLAY;
+  if (!display) {
+    return {
+      supported: false,
+      preview: false,
+      reason:
+        "WSL is detected, but no Linux graphical display is available. Enable WSLg (or an X server), install Chrome/Chromium inside the WSL distribution, and retry.",
+    };
+  }
+
+  return {
+    supported: true,
+    preview: true,
+    reason:
+      `WSL is detected with ${env.WAYLAND_DISPLAY ? "Wayland" : "X11"} display support. `
+      + "WTAgent uses Chrome/Chromium installed inside the WSL distribution; Windows-host Chrome is not used.",
+  };
+}
+
 export function getNativeWindowsSupport({
   platform = process.platform,
   arch = process.arch,
@@ -100,11 +128,12 @@ export function assertNativeRuntimeSupported(context = {}) {
       `WTAgent requires Node.js 20.17.0 or newer; current runtime is ${version}.`,
     );
   }
-  if (detectWsl(context)) {
-    throw new Error(
-      "WTAgent does not support running inside WSL in v1. Launch it from native Windows PowerShell or CMD against a Windows project path.",
-    );
+
+  const wsl = getWslSupport(context);
+  if (!wsl.supported) {
+    throw new Error(wsl.reason);
   }
+
   const windows = getNativeWindowsSupport(context);
   if (!windows.supported) {
     throw new Error(windows.reason);
@@ -356,11 +385,12 @@ export async function collectDoctorReport({
 
   const isWsl = detectWsl({ platform, env, osRelease });
   if (isWsl) {
+    const wsl = getWslSupport({ platform, env, osRelease });
     add(
       "host",
       "Runtime host",
-      "fail",
-      "WSL is detected. WTAgent v1 must run from native Windows PowerShell or CMD, not from WSL.",
+      wsl.supported ? "pass" : "fail",
+      wsl.reason,
       { required: true },
     );
   } else {

--- a/test/windows-diagnostics.test.js
+++ b/test/windows-diagnostics.test.js
@@ -7,6 +7,7 @@ import {
   detectWsl,
   findExecutableOnPath,
   getNativeWindowsSupport,
+  getWslSupport,
   isSupportedNodeVersion,
 } from "../src/platform/windows-diagnostics.js";
 
@@ -34,14 +35,36 @@ test("detects WSL from environment and kernel release", () => {
   }), false);
 });
 
-test("WSL runtime is rejected with a native-Windows remediation", () => {
+test("WSL runtime is supported with a Linux graphical display", () => {
+  const context = {
+    platform: "linux",
+    env: {
+      WSL_DISTRO_NAME: "Ubuntu",
+      WAYLAND_DISPLAY: "wayland-0",
+    },
+    osRelease: "6.6.0-microsoft-standard-WSL2",
+  };
+
+  const support = getWslSupport(context);
+  assert.equal(support.supported, true);
+  assert.equal(support.preview, true);
+  assert.match(support.reason, /inside the WSL distribution/i);
+  assert.doesNotThrow(() => assertNativeRuntimeSupported(context));
+});
+
+test("WSL runtime requires WSLg or another Linux graphical display", () => {
+  const context = {
+    platform: "linux",
+    env: { WSL_DISTRO_NAME: "Ubuntu" },
+    osRelease: "6.6.0-microsoft-standard-WSL2",
+  };
+
+  const support = getWslSupport(context);
+  assert.equal(support.supported, false);
+  assert.match(support.reason, /WSLg|X server/i);
   assert.throws(
-    () => assertNativeRuntimeSupported({
-      platform: "linux",
-      env: { WSL_DISTRO_NAME: "Ubuntu" },
-      osRelease: "6.6.0",
-    }),
-    /native Windows PowerShell or CMD/i,
+    () => assertNativeRuntimeSupported(context),
+    /WSLg|X server/i,
   );
 });
 
@@ -90,6 +113,43 @@ test("findExecutableOnPath skips bundled Codex tool paths", async () => {
     }),
   });
   assert.equal(result, "/usr/local/bin/rg");
+});
+
+test("doctor report accepts WSL when Linux GUI Chrome is available", async () => {
+  const paths = {
+    appDataDir: path.join("/tmp", "wtagent-home"),
+    sessionsDir: path.join("/tmp", "wtagent-home", "sessions"),
+    profileDir: path.join("/tmp", "wtagent-home", "chrome-profile"),
+  };
+  const report = await collectDoctorReport(
+    { paths, chromePath: undefined },
+    {
+      platform: "linux",
+      arch: "x64",
+      version: "v20.17.0",
+      env: {
+        WSL_DISTRO_NAME: "Ubuntu",
+        WAYLAND_DISPLAY: "wayland-0",
+      },
+      osRelease: "6.6.0-microsoft-standard-WSL2",
+      access: async () => {},
+      stat: async () => ({ isDirectory: () => true }),
+      discoverChrome: () => "/usr/bin/google-chrome",
+      inspectProfile: async () => ({
+        status: "pass",
+        detail: "no saved CDP state",
+      }),
+      findExecutable: async () => null,
+    },
+  );
+
+  assert.equal(report.exitCode, 0);
+  assert.equal(report.items.find((item) => item.id === "host").status, "pass");
+  assert.equal(report.items.find((item) => item.id === "chrome").status, "pass");
+  assert.equal(
+    report.items.some((item) => item.id === "command-bridge"),
+    false,
+  );
 });
 
 test("doctor report distinguishes required failures, degraded checks, and optional tools", async () => {


### PR DESCRIPTION
## Summary

Add preview support for running WTAgent inside WSL when a Linux graphical
display is available through WSLg or X11.

WTAgent continues to use the existing Linux runtime path:

- local tools and commands run inside WSL
- Chrome/Chromium is installed and launched inside WSL
- CDP stays on the WSL loopback interface
- existing profile, session, and process-management behavior is preserved

Windows-host Chrome is intentionally out of scope for this change.

## Changes

- allow WSL when `WAYLAND_DISPLAY` or `DISPLAY` is available
- keep rejecting headless WSL environments without a graphical display
- update `wtagent doctor` to report supported WSL environments
- add unit coverage for supported and unsupported WSL configurations
- document WSL requirements in the README

## Manual testing

Tested successfully with:

- WSL2 Ubuntu
- WSLg / Wayland
- Node.js 24
- Google Chrome 142
- `wtagent doctor`
- ChatGPT login with the dedicated WTAgent Chrome profile
- normal WTAgent agent workflow

`wtagent doctor` reports `Doctor: OK`, and the end-to-end browser/CDP flow
works successfully.

## Out of scope

This PR does not launch or control Windows-host Chrome from WSL. Supporting
that requires separate handling for Windows profile paths, CDP networking,
process discovery, and process lifecycle management.